### PR TITLE
[t9206] S02 10.049 Customer Specific Product References and Names

### DIFF
--- a/partner_affiliate/models/res_partner.py
+++ b/partner_affiliate/models/res_partner.py
@@ -3,7 +3,7 @@
 # Copyright 2018 brain-tec AG - Raul Martin
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models, api, _
+from odoo import fields, models, api
 
 
 class ResPartner(models.Model):

--- a/partner_affiliate/models/res_partner.py
+++ b/partner_affiliate/models/res_partner.py
@@ -3,7 +3,7 @@
 # Copyright 2018 brain-tec AG - Raul Martin
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models, api
+from odoo import fields, models, api, _
 
 
 class ResPartner(models.Model):
@@ -23,3 +23,31 @@ class ResPartner(models.Model):
                                     string='Affiliates',
                                     domain=[('active', '=', True),
                                             ('is_company', '=', True)])
+
+    @api.onchange('parent_id')
+    def onchange_parent_id(self):
+        # Keep the original address info to set it back if is a company.
+        original_address = self.get_original_address()
+
+        new_partner = super(ResPartner, self).onchange_parent_id()
+
+        # When the affiliate is a company, we must set back its address
+        # because the super call changes its address by the new parent address.
+        # In addition, the type must be set to affiliate instead of contact.
+        if self.is_company:
+            self.type = 'affiliate'
+            self.update_address(original_address)
+            return
+
+        return new_partner
+
+    def get_original_address(self):
+        def convert(value):
+            return value.id if isinstance(value, models.BaseModel) else value
+
+        result = {}
+        if any(self.parent_id[key] for key in self._address_fields()):
+            result['value'] = {key: convert(self.parent_id[key])
+                               for key in self._address_fields()}
+
+        return result

--- a/partner_affiliate/models/res_partner.py
+++ b/partner_affiliate/models/res_partner.py
@@ -24,9 +24,18 @@ class ResPartner(models.Model):
                                     domain=[('active', '=', True),
                                             ('is_company', '=', True)])
 
+    def get_original_address(self):
+        def convert(value):
+            return value.id if isinstance(value, models.BaseModel) else value
+
+        result = {'value': {key: convert(self[key])
+                            for key in self._address_fields()}}
+
+        return result
+
     @api.onchange('parent_id')
     def onchange_parent_id(self):
-        # Keep the original address info to set it back if is a company.
+        # Keep the original address info to set it back if its a company.
         original_address = self.get_original_address()
 
         new_partner = super(ResPartner, self).onchange_parent_id()
@@ -35,19 +44,7 @@ class ResPartner(models.Model):
         # because the super call changes its address by the new parent address.
         # In addition, the type must be set to affiliate instead of contact.
         if self.is_company:
-            self.type = 'affiliate'
-            self.update_address(original_address)
-            return
+            new_partner.update(original_address)
+            new_partner['value'].update({'type': 'affiliate'})
 
         return new_partner
-
-    def get_original_address(self):
-        def convert(value):
-            return value.id if isinstance(value, models.BaseModel) else value
-
-        result = {}
-        if any(self.parent_id[key] for key in self._address_fields()):
-            result['value'] = {key: convert(self.parent_id[key])
-                               for key in self._address_fields()}
-
-        return result

--- a/partner_affiliate/tests/test_partner_affiliate.py
+++ b/partner_affiliate/tests/test_partner_affiliate.py
@@ -7,83 +7,89 @@ class TestPartnerAffiliate(common.TransactionCase):
         super(TestPartnerAffiliate, self).setUp()
         self.partner_obj = self.env['res.partner']
 
-        self.first_parent = self.partner_obj.create({
-            'name': 'MyFirstParentForTheAffiliate',
+        self.first_company = self.partner_obj.create({
+            'name': 'MyFirstCompanyForTheAffiliate',
             'type': 'contact',
             'is_company': True,
-            'street': 'first parent street',
-            'street2': 'number 99',
-            'zip': 123,
-            'city': 'Test City',
+            'street': 'first company street',
         })
 
-        self.second_parent = self.partner_obj.create({
-            'name': 'MySecondParentForTheAffiliate',
+        self.second_company = self.partner_obj.create({
+            'name': 'MySecondCompanyForTheAffiliate',
             'type': 'contact',
             'is_company': True,
-            'street': 'second parent street',
-            'street2': 'number 44',
-            'zip': 999,
-            'city': 'Test City',
+            'street': 'second company street',
         })
 
     # Check data integrity of the objects when an affiliate is given a new
     # parent. So both objects keeps their data.
     def test_change_parent_from_a_new_affiliate(self):
-        new_affiliate = self.partner_obj.create({
-            'name': 'MyTestAffiliate',
+        my_affiliate = self.partner_obj.create({
+            'name': 'MyAffiliate',
             'is_company': True,
-            'parent_id': self.first_parent.id,
+            'parent_id': self.first_company.id,
             'type': 'affiliate',
             'street': 'affiliate street',
-            'street2': 'number 11',
-            'zip': 567,
-            'city': 'Test City',
-            'email': 'myAffiliate@test.com',
         })
 
         # Checks for data integrity in affiliate and his parent.
-        self.assertTrue(new_affiliate, "The new affiliate have been created.")
+        self.assertTrue(my_affiliate, "The new affiliate have been created.")
 
-        self.assertEquals(new_affiliate.type, 'affiliate',
+        self.assertEquals(my_affiliate.type, 'affiliate',
                           "Check type must be 'affiliate'")
-        self.assertEquals(new_affiliate.parent_id.id, self.first_parent.id,
+        self.assertEquals(my_affiliate.parent_id.id, self.first_company.id,
                           "Must be child of the parent defined in the setup")
-        self.assertEquals(new_affiliate.street, "affiliate street",
+        self.assertEquals(my_affiliate.street, "affiliate street",
                           "The street have been correctly set.")
-        self.assertEquals(self.first_parent.street, "first parent street",
+        self.assertEquals(self.first_company.street, "first company street",
                           "The parent continues with his original street")
 
         # Change the parent of the affiliate for the second one in the set-up.
-        new_affiliate.parent_id = self.second_parent.id
-        new_affiliate.onchange_parent_id()
+        my_affiliate.parent_id = self.second_company.id
+        my_affiliate.onchange_parent_id()
 
         # The parent have been changed. And is not the first one.
-        self.assertEquals(new_affiliate.parent_id.id, self.second_parent.id)
+        self.assertEquals(my_affiliate.parent_id.id, self.second_company.id)
 
-        # The affiliate keeps its data for the street. Not modified.
-        self.assertEquals(new_affiliate.street, "affiliate street",
+        # The affiliate keeps its data for the street (address). Not modified.
+        self.assertEquals(my_affiliate.street, "affiliate street",
                           "keeps the same street")
         # The data for the street of the first parent have not been changed.
-        self.assertEquals(self.first_parent.street, "first parent street",
+        self.assertEquals(self.first_company.street, "first company street",
                           "keeps the same street")
-
 
     # Check that the default value for 'type' defined by default in the view
     # is set correctly when a new affiliate is created.
     def test_new_affiliate_is_created_with_type_affiliate_by_default(self):
         new_affiliate = self.partner_obj.with_context(
-            {'default_parent_id': self.first_parent.id,
+            {'default_parent_id': self.first_company.id,
              'default_is_company': True,
              'default_type': 'affiliate'
              }
         ).create({
             'name': 'MyTestAffiliate',
             'street': 'affiliate street',
-            'street2': 'number 11',
-            'zip': 567,
-            'city': 'Test City',
-            'email': 'myAffiliate@test.com',
         })
 
         self.assertEquals(new_affiliate.type, 'affiliate')
+
+    # Check that when changing the parent from an individual, it changes also
+    # the address keeping the expected behaviour.
+    def test_individual_changes_address_when_changing_parent_id(self):
+        my_individual = self.partner_obj.create({
+            'name': 'MyIndividual',
+            'parent_id': self.first_company.id,
+            'type': 'contact',
+            'is_company': False,
+            'street': 'individual street',
+        })
+
+        my_individual.parent_id = self.second_company.id
+        my_individual.onchange_parent_id()
+
+        # The parent have been changed.
+        self.assertEquals(my_individual.parent_id.id, self.second_company.id)
+
+        # The affiliate gets the address from the new parent.
+        self.assertEquals(my_individual.street, "second company street",
+                          "keeps the same street")

--- a/partner_affiliate/views/res_partner_view.xml
+++ b/partner_affiliate/views/res_partner_view.xml
@@ -14,7 +14,7 @@
             <xpath expr='//page[@name="internal_notes"]' position="before">
                 <page string="Affiliates" attrs="{'invisible': [('is_company','=',False)]}">
                     <field name="affiliate_ids"
-                           context="{'default_parent_id': active_id, 'default_is_company': True, 'default_type':'affiliate'}" mode="kanban">
+                           context="{'default_parent_id': active_id, 'default_is_company': True}" mode="kanban">
                         <kanban>
                             <field name="color"/>
                             <field name="name"/>


### PR DESCRIPTION
User Story: As a sales support staff I can add customer specific product names and references to products to use those terms in offers, confirmations, invoices that are sent to the customer.

Ticket: [bt#2105] Partner Affiliate Still Overwrites Companies' Addresses (#2105)

Install module partner-contact; affiliate 