### PR TITLE
[bt#19495] Fix Invalid Field Usage

### DIFF
--- a/partner_multi_relation/models/res_partner_relation_all.py
+++ b/partner_multi_relation/models/res_partner_relation_all.py
@@ -376,6 +376,7 @@ CREATE OR REPLACE VIEW %%(table)s AS
             "type_selection_id",
             "other_partner_id",
             "is_inverse",
+            "any_partner_id",
         ):
             if key in vals:
                 del vals[key]


### PR DESCRIPTION
Remove invalid field in ResPartnerRelationAll._correct_vals() method as this is leading to errors for some users.

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.bt-group.com/web#view_type=form&model=helpdesk.ticket&id=19495">[bt#19495] Re: Missings in staging (VS Prod) (#5939)</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>partner_multi_relation</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->